### PR TITLE
Fixing an incorrect minus sign as well as double quotationmark in PrepareForImageStreamerOSVolumeCapture.ps1

### DIFF
--- a/scripts/PrepareForImageStreamerOSVolumeCapture.ps1
+++ b/scripts/PrepareForImageStreamerOSVolumeCapture.ps1
@@ -41,7 +41,7 @@ Try
     # Generalize Windows with sysprep, but quit rather than reboot or shutdown
     & $env:windir\System32\Sysprep\sysprep /generalize /oobe /quit
     
-    Wait-Process –Name “sysprep”
+    Wait-Process -Name "sysprep"
     
     reg import C:\driveletters.reg
     


### PR DESCRIPTION
This problem exists in the 4.2 branch.